### PR TITLE
Reset JSContext exception after processing

### DIFF
--- a/Sources/MathJaxSwift/MathJax.swift
+++ b/Sources/MathJaxSwift/MathJax.swift
@@ -224,7 +224,8 @@ extension MathJax {
     guard let exception = context.exception else {
       return
     }
-    
+    // Reset the exception so it does not pollute all subsequent calls
+    context.exception = nil
     // Throw its string value.
     throw MathJaxError.javascriptException(value: exception.toString())
   }


### PR DESCRIPTION
The current implementation never resets the `JSContext` `exception` property. This means that a single exception will pollute all subsequent calls to MathJaxSwift e.g.

1. `try tex2svg(input1)` throws
2. `MathJax.context.exception` is now non-nil
3. `try tex2svg(input2)` should succeed, but still throws because of `input1` exception

The naive fix is to reset the `context.exception` after checking for the current exception.
